### PR TITLE
Add organization based checking for response object

### DIFF
--- a/auth/dream-spring-auth-base/src/main/java/com/dream/springframework/auth/base/annotation/OrgAuthorization.java
+++ b/auth/dream-spring-auth-base/src/main/java/com/dream/springframework/auth/base/annotation/OrgAuthorization.java
@@ -23,21 +23,22 @@ import com.dream.springframework.auth.base.model.CheckedOrgs;
 import java.lang.annotation.*;
 
 /**
- * Annotates on {@link org.springframework.web.bind.annotation.PathVariable}, {@link org.springframework.web.bind.annotation.RequestParam}
- * or {@link org.springframework.web.bind.annotation.RequestBody} annotated parameter which represents or contains organization identity
- * to check the authorities and roles.
+ * Annotate on {@link org.springframework.web.bind.annotation.PathVariable}, {@link org.springframework.web.bind.annotation.RequestParam},
+ * {@link org.springframework.web.bind.annotation.RequestBody} annotated parameter or method which represents or contains organization
+ * identity to check the authorities and roles.
  * <ul>
- * <li>This annotation should be used in combine with {@link RequiredAuthorities} or
- * {@link RequiredRoles} to check authorities or roles based on organization</li>
+ * <li>This annotation should be used in combine with {@link RequiredAuthorities} or {@link RequiredRoles} to check authorities or roles
+ * based on organization</li>
  * <li>{@link org.springframework.web.bind.annotation.PathVariable} or {@link org.springframework.web.bind.annotation.RequestParam}
  * annotated parameter that annotated with this annotation should represents the organization identity</li>
  * <li>{@link org.springframework.web.bind.annotation.RequestBody} annotated parameter that annotated with this annotation should
  * implement {@link CheckedOrg}, {@link CheckedOrgList} or {@link CheckedOrgs}</li>
+ * <li>when annotated on the method, the response object will be used to check authorities or roles</li>
  * </ul>
  *
  * @author DreamJM
  */
-@Target(ElementType.PARAMETER)
+@Target({ElementType.PARAMETER, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface OrgAuthorization {

--- a/auth/dream-spring-auth-base/src/main/java/com/dream/springframework/auth/base/component/AuthenticationInterceptor.java
+++ b/auth/dream-spring-auth-base/src/main/java/com/dream/springframework/auth/base/component/AuthenticationInterceptor.java
@@ -76,6 +76,8 @@ public class AuthenticationInterceptor extends HandlerInterceptorAdapter {
                 Boolean orgCheckBool = orgCheckMethodMap.get(method.getMethod());
                 if (orgCheckBool != null) {
                     orgCheck = orgCheckBool;
+                } else if (method.hasMethodAnnotation(OrgAuthorization.class)) {
+                    orgCheck = true;
                 } else {
                     for (MethodParameter parameter : method.getMethodParameters()) {
                         if (parameter.hasParameterAnnotation(OrgAuthorization.class)) {

--- a/auth/dream-spring-auth-base/src/main/java/com/dream/springframework/auth/base/component/OrgCheckAdvice.java
+++ b/auth/dream-spring-auth-base/src/main/java/com/dream/springframework/auth/base/component/OrgCheckAdvice.java
@@ -16,178 +16,56 @@
 
 package com.dream.springframework.auth.base.component;
 
-import com.dream.springframework.auth.base.BaseAuthUser;
-import com.dream.springframework.auth.base.annotation.*;
-import com.dream.springframework.auth.base.model.CheckedOrg;
-import com.dream.springframework.auth.base.model.CheckedOrgList;
-import com.dream.springframework.auth.base.model.CheckedOrgs;
 import com.dream.springframework.auth.base.service.AuthorizationService;
 import com.dream.springframework.auth.base.service.OrgPermissionService;
-import com.dream.springframework.base.exception.RequestException;
-import com.dream.springframework.base.exception.RuntimeRequestException;
-import com.google.common.base.Strings;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.util.ReflectionUtils;
+import org.springframework.lang.NonNull;
 import org.springframework.web.bind.annotation.ControllerAdvice;
-import org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdviceAdapter;
+import org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdvice;
 
 import javax.servlet.http.HttpServletRequest;
-import java.lang.reflect.Array;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.Collection;
 
 /**
- * Checks organization resource permission
+ * Checks organization resource permission and organization based authorities and roles
  *
  * @author DreamJM
  */
 @ControllerAdvice
-public class OrgCheckAdvice extends RequestBodyAdviceAdapter {
-
-    private HttpServletRequest request;
-
-    private OrgPermissionService<?> permissionService;
-
-    private AuthorizationService authService;
+public class OrgCheckAdvice extends OrgCheckService implements RequestBodyAdvice {
 
     public OrgCheckAdvice(ObjectProvider<OrgPermissionService<?>> permissionProvider, AuthorizationService authService,
                           HttpServletRequest request) {
-        this.permissionService = permissionProvider.getIfAvailable();
-        this.authService = authService;
-        this.request = request;
+        super(permissionProvider, authService, request, false);
     }
 
     @Override
-    public boolean supports(MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
-        if (methodParameter.getMethod() == null || methodParameter.getMethodAnnotation(AuthIgnore.class) != null) {
-            return false;
-        }
-        if (permissionService == null && !methodParameter.hasParameterAnnotation(OrgAuthorization.class)) {
-            return false;
-        }
-        if (targetType instanceof ParameterizedType) {
-            ParameterizedType parameterizedType = (ParameterizedType) targetType;
-            if (parameterizedType.getRawType() instanceof Class && Collection.class
-                    .isAssignableFrom((Class<?>) parameterizedType.getRawType())) {
-                Type[] genericTypes = parameterizedType.getActualTypeArguments();
-                if (genericTypes != null && genericTypes.length > 0 && genericTypes[0] instanceof Class) {
-                    return checkClassType((Class<?>) genericTypes[0]);
-                }
-            }
-            return false;
-        }
-        Class<?> targetClass = (Class<?>) targetType;
-        if (targetClass.isArray()) {
-            targetClass = targetClass.getComponentType();
-        }
-        return checkClassType(targetClass);
+    public boolean supports(@NonNull MethodParameter methodParameter, @NonNull Type targetType,
+                            @NonNull Class<? extends HttpMessageConverter<?>> converterType) {
+        return supports(methodParameter);
     }
 
-    private boolean checkClassType(Class<?> targetClass) {
-        return CheckedOrg.class.isAssignableFrom(targetClass) || CheckedOrgList.class.isAssignableFrom(targetClass) || CheckedOrgs.class
-                .isAssignableFrom(targetClass);
-    }
-
+    @NonNull
     @Override
-    public Object afterBodyRead(Object body, HttpInputMessage inputMessage, MethodParameter parameter, Type targetType,
-                                Class<? extends HttpMessageConverter<?>> converterType) {
-        BaseAuthUser authUser = (BaseAuthUser) request.getAttribute(BaseAuthUser.USER_KEY);
-        if (parameter.getMethod() == null || authUser == null) {
-            return body;
-        }
-        if (parameter.hasMethodAnnotation(OrgPermissionIgnore.class) && !parameter.hasParameterAnnotation(OrgAuthorization.class)) {
-            return body;
-        }
-        RequiredAuthorities authAnnotation = parameter.getMethodAnnotation(RequiredAuthorities.class);
-        RequiredRoles roleAnnotation = parameter.getMethodAnnotation(RequiredRoles.class);
-        try {
-            checkAuthAndPermission(body, parameter, authUser, authAnnotation, roleAnnotation);
-        } catch (RequestException ex) {
-            throw new RuntimeRequestException(ex);
-        }
+    public HttpInputMessage beforeBodyRead(@NonNull HttpInputMessage inputMessage, @NonNull MethodParameter parameter,
+                                           @NonNull Type targetType, @NonNull Class<? extends HttpMessageConverter<?>> converterType) {
+        return inputMessage;
+    }
+
+    @NonNull
+    @Override
+    public Object afterBodyRead(@NonNull Object body, @NonNull HttpInputMessage inputMessage, @NonNull MethodParameter parameter,
+                                @NonNull Type targetType, @NonNull Class<? extends HttpMessageConverter<?>> converterType) {
+        checkAdvice(body, parameter);
         return body;
     }
 
-    private void checkAuthAndPermission(Object body, MethodParameter parameter, BaseAuthUser authUser, RequiredAuthorities authAnnotation,
-                                        RequiredRoles roleAnnotation) throws RequestException {
-        if (body instanceof CheckedOrg) {
-            checkOrg((CheckedOrg) body, parameter, authUser, authAnnotation, roleAnnotation);
-        } else if (body instanceof CheckedOrgs) {
-            checkOrgs((CheckedOrgs) body, parameter, authUser, authAnnotation, roleAnnotation);
-        } else if (body instanceof CheckedOrgList) {
-            checkOrgList((CheckedOrgList) body, parameter, authUser, authAnnotation, roleAnnotation);
-        } else if (body.getClass().isArray()) {
-            for (int i = 0; i < Array.getLength(body); i++) {
-                checkAuthAndPermission(Array.get(body, i), parameter, authUser, authAnnotation, roleAnnotation);
-            }
-        } else if (body instanceof Collection) {
-            Collection<?> collection = (Collection<?>) body;
-            for (Object item : collection) {
-                checkAuthAndPermission(item, parameter, authUser, authAnnotation, roleAnnotation);
-            }
-        }
-    }
-
-    private void checkOrg(CheckedOrg orgCheck, MethodParameter parameter, BaseAuthUser authUser, RequiredAuthorities authAnnotation,
-                          RequiredRoles roleAnnotation) throws RequestException {
-        if (permissionService != null && !parameter.hasMethodAnnotation(OrgPermissionIgnore.class) && !Strings
-                .isNullOrEmpty(orgCheck.getCheckOrgId())) {
-            //noinspection unchecked
-            orgCheck.setCheckedOrg(permissionService.checkOrgResourcePermission(authUser.getOrgIds(), orgCheck.getCheckOrgId()));
-        }
-        if (parameter.hasParameterAnnotation(OrgAuthorization.class)) {
-            authService.authorize(authUser, orgCheck.getCheckOrgId(), authAnnotation, roleAnnotation);
-        }
-    }
-
-    private void checkOrgs(CheckedOrgs orgsCheck, MethodParameter parameter, BaseAuthUser authUser, RequiredAuthorities authAnnotation,
-                           RequiredRoles roleAnnotation) throws RequestException {
-        if (permissionService != null && !parameter.hasMethodAnnotation(OrgPermissionIgnore.class) && orgsCheck
-                .getCheckOrgIds() != null && !orgsCheck.getCheckOrgIds().isEmpty()) {
-            //noinspection unchecked
-            orgsCheck.setCheckedOrgs(permissionService.checkOrgsResourcePermission(authUser.getOrgIds(), orgsCheck.getCheckOrgIds()));
-        }
-        if (parameter.hasParameterAnnotation(OrgAuthorization.class)) {
-            if (authAnnotation == null && roleAnnotation == null) {
-                return;
-            }
-            if (orgsCheck.getCheckOrgIds() == null || orgsCheck.getCheckOrgIds().isEmpty()) {
-                authService.authorize(authUser, null, authAnnotation, roleAnnotation);
-            } else {
-                for (Object checkOrgId : orgsCheck.getCheckOrgIds()) {
-                    authService.authorize(authUser, (String) checkOrgId, authAnnotation, roleAnnotation);
-                }
-            }
-        }
-    }
-
-    private void checkOrgList(CheckedOrgList orgCheckList, MethodParameter parameter, BaseAuthUser authUser,
-                              RequiredAuthorities authAnnotation,
-                              RequiredRoles roleAnnotation) throws RequestException {
-        if (permissionService != null && !parameter.hasMethodAnnotation(OrgPermissionIgnore.class) && orgCheckList
-                .getCheckOrgs() != null && !orgCheckList.getCheckOrgs().isEmpty()) {
-            for (Object obj : orgCheckList.getCheckOrgs()) {
-                CheckedOrg orgCheck = (CheckedOrg) obj;
-                //noinspection unchecked
-                orgCheck.setCheckedOrg(permissionService.checkOrgResourcePermission(authUser.getOrgIds(), orgCheck.getCheckOrgId()));
-            }
-        }
-        if (parameter.hasParameterAnnotation(OrgAuthorization.class)) {
-            if (authAnnotation == null && roleAnnotation == null) {
-                return;
-            }
-            if (orgCheckList.getCheckOrgs() == null || orgCheckList.getCheckOrgs().isEmpty()) {
-                authService.authorize(authUser, null, authAnnotation, roleAnnotation);
-            } else {
-                for (Object obj : orgCheckList.getCheckOrgs()) {
-                    CheckedOrg orgCheck = (CheckedOrg) obj;
-                    authService.authorize(authUser, orgCheck.getCheckOrgId(), authAnnotation, roleAnnotation);
-                }
-            }
-        }
+    @Override
+    public Object handleEmptyBody(Object body, @NonNull HttpInputMessage inputMessage, @NonNull MethodParameter parameter,
+                                  @NonNull Type targetType, @NonNull Class<? extends HttpMessageConverter<?>> converterType) {
+        return body;
     }
 }

--- a/auth/dream-spring-auth-base/src/main/java/com/dream/springframework/auth/base/component/OrgCheckService.java
+++ b/auth/dream-spring-auth-base/src/main/java/com/dream/springframework/auth/base/component/OrgCheckService.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dream.springframework.auth.base.component;
+
+import com.dream.springframework.auth.base.BaseAuthUser;
+import com.dream.springframework.auth.base.annotation.*;
+import com.dream.springframework.auth.base.model.CheckedOrg;
+import com.dream.springframework.auth.base.model.CheckedOrgList;
+import com.dream.springframework.auth.base.model.CheckedOrgs;
+import com.dream.springframework.auth.base.service.AuthorizationService;
+import com.dream.springframework.auth.base.service.OrgPermissionService;
+import com.dream.springframework.base.exception.RequestException;
+import com.dream.springframework.base.exception.RuntimeRequestException;
+import com.google.common.base.Strings;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.MethodParameter;
+
+import javax.servlet.http.HttpServletRequest;
+import java.lang.reflect.Array;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+
+/**
+ * Base service for organization resource permission and organization based authorities and roles checking
+ *
+ * @author DreamJM
+ */
+class OrgCheckService {
+
+    private HttpServletRequest request;
+
+    private OrgPermissionService<?> permissionService;
+
+    private AuthorizationService authService;
+
+    private boolean returnValue;
+
+    OrgCheckService(ObjectProvider<OrgPermissionService<?>> permissionProvider, AuthorizationService authService,
+                    HttpServletRequest request, boolean returnValue) {
+        this.permissionService = permissionProvider.getIfAvailable();
+        this.authService = authService;
+        this.request = request;
+        this.returnValue = returnValue;
+    }
+
+    boolean supports(MethodParameter methodParameter) {
+        if (methodParameter.getMethod() == null || methodParameter.getMethodAnnotation(AuthIgnore.class) != null) {
+            return false;
+        }
+        if (permissionService == null && !orgAuthorizationAnnotated(methodParameter)) {
+            return false;
+        }
+        if (methodParameter.getGenericParameterType() instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType) methodParameter.getGenericParameterType();
+            if (parameterizedType.getRawType() instanceof Class && Collection.class
+                    .isAssignableFrom((Class<?>) parameterizedType.getRawType())) {
+                Type[] genericTypes = parameterizedType.getActualTypeArguments();
+                if (genericTypes != null && genericTypes.length > 0 && genericTypes[0] instanceof Class) {
+                    return checkClassType((Class<?>) genericTypes[0]);
+                }
+            }
+            return false;
+        }
+        Class<?> targetClass = methodParameter.getParameterType();
+        if (targetClass.isArray()) {
+            targetClass = targetClass.getComponentType();
+        }
+        return checkClassType(targetClass);
+    }
+
+    private boolean checkClassType(Class<?> targetClass) {
+        return CheckedOrg.class.isAssignableFrom(targetClass) || CheckedOrgList.class.isAssignableFrom(targetClass) || CheckedOrgs.class
+                .isAssignableFrom(targetClass);
+    }
+
+    void checkAdvice(Object body, MethodParameter parameter) {
+        BaseAuthUser authUser = (BaseAuthUser) request.getAttribute(BaseAuthUser.USER_KEY);
+        if (parameter.getMethod() == null || authUser == null) {
+            return;
+        }
+        if (parameter.hasMethodAnnotation(OrgPermissionIgnore.class) && !orgAuthorizationAnnotated(parameter)) {
+            return;
+        }
+        RequiredAuthorities authAnnotation = parameter.getMethodAnnotation(RequiredAuthorities.class);
+        RequiredRoles roleAnnotation = parameter.getMethodAnnotation(RequiredRoles.class);
+        try {
+            checkAuthAndPermission(body, parameter, authUser, authAnnotation, roleAnnotation);
+        } catch (RequestException ex) {
+            throw new RuntimeRequestException(ex);
+        }
+    }
+
+    private void checkAuthAndPermission(Object body, MethodParameter parameter, BaseAuthUser authUser, RequiredAuthorities authAnnotation,
+                                        RequiredRoles roleAnnotation) throws RequestException {
+        if (body instanceof CheckedOrg) {
+            checkOrg((CheckedOrg) body, parameter, authUser, authAnnotation, roleAnnotation);
+        } else if (body instanceof CheckedOrgs) {
+            checkOrgs((CheckedOrgs) body, parameter, authUser, authAnnotation, roleAnnotation);
+        } else if (body instanceof CheckedOrgList) {
+            checkOrgList((CheckedOrgList) body, parameter, authUser, authAnnotation, roleAnnotation);
+        } else if (body.getClass().isArray()) {
+            for (int i = 0; i < Array.getLength(body); i++) {
+                checkAuthAndPermission(Array.get(body, i), parameter, authUser, authAnnotation, roleAnnotation);
+            }
+        } else if (body instanceof Collection) {
+            Collection<?> collection = (Collection<?>) body;
+            for (Object item : collection) {
+                checkAuthAndPermission(item, parameter, authUser, authAnnotation, roleAnnotation);
+            }
+        }
+    }
+
+    private void checkOrg(CheckedOrg orgCheck, MethodParameter parameter, BaseAuthUser authUser, RequiredAuthorities authAnnotation,
+                          RequiredRoles roleAnnotation) throws RequestException {
+        if (permissionService != null && !parameter.hasMethodAnnotation(OrgPermissionIgnore.class) && !Strings
+                .isNullOrEmpty(orgCheck.getCheckOrgId())) {
+            //noinspection unchecked
+            orgCheck.setCheckedOrg(permissionService.checkOrgResourcePermission(authUser.getOrgIds(), orgCheck.getCheckOrgId()));
+        }
+        if (orgAuthorizationAnnotated(parameter)) {
+            authService.authorize(authUser, orgCheck.getCheckOrgId(), authAnnotation, roleAnnotation);
+        }
+    }
+
+    private void checkOrgs(CheckedOrgs orgsCheck, MethodParameter parameter, BaseAuthUser authUser, RequiredAuthorities authAnnotation,
+                           RequiredRoles roleAnnotation) throws RequestException {
+        if (permissionService != null && !parameter.hasMethodAnnotation(OrgPermissionIgnore.class) && orgsCheck
+                .getCheckOrgIds() != null && !orgsCheck.getCheckOrgIds().isEmpty()) {
+            //noinspection unchecked
+            orgsCheck.setCheckedOrgs(permissionService.checkOrgsResourcePermission(authUser.getOrgIds(), orgsCheck.getCheckOrgIds()));
+        }
+        if (orgAuthorizationAnnotated(parameter)) {
+            if (authAnnotation == null && roleAnnotation == null) {
+                return;
+            }
+            if (orgsCheck.getCheckOrgIds() == null || orgsCheck.getCheckOrgIds().isEmpty()) {
+                authService.authorize(authUser, null, authAnnotation, roleAnnotation);
+            } else {
+                for (Object checkOrgId : orgsCheck.getCheckOrgIds()) {
+                    authService.authorize(authUser, (String) checkOrgId, authAnnotation, roleAnnotation);
+                }
+            }
+        }
+    }
+
+    private void checkOrgList(CheckedOrgList orgCheckList, MethodParameter parameter, BaseAuthUser authUser,
+                              RequiredAuthorities authAnnotation,
+                              RequiredRoles roleAnnotation) throws RequestException {
+        if (permissionService != null && !parameter.hasMethodAnnotation(OrgPermissionIgnore.class) && orgCheckList
+                .getCheckOrgs() != null && !orgCheckList.getCheckOrgs().isEmpty()) {
+            for (Object obj : orgCheckList.getCheckOrgs()) {
+                CheckedOrg orgCheck = (CheckedOrg) obj;
+                //noinspection unchecked
+                orgCheck.setCheckedOrg(permissionService.checkOrgResourcePermission(authUser.getOrgIds(), orgCheck.getCheckOrgId()));
+            }
+        }
+        if (orgAuthorizationAnnotated(parameter)) {
+            if (authAnnotation == null && roleAnnotation == null) {
+                return;
+            }
+            if (orgCheckList.getCheckOrgs() == null || orgCheckList.getCheckOrgs().isEmpty()) {
+                authService.authorize(authUser, null, authAnnotation, roleAnnotation);
+            } else {
+                for (Object obj : orgCheckList.getCheckOrgs()) {
+                    CheckedOrg orgCheck = (CheckedOrg) obj;
+                    authService.authorize(authUser, orgCheck.getCheckOrgId(), authAnnotation, roleAnnotation);
+                }
+            }
+        }
+    }
+
+    private boolean orgAuthorizationAnnotated(MethodParameter parameter) {
+        return returnValue ? parameter.hasMethodAnnotation(OrgAuthorization.class) : parameter
+                .hasParameterAnnotation(OrgAuthorization.class);
+    }
+
+}

--- a/auth/dream-spring-auth-base/src/main/java/com/dream/springframework/auth/base/component/OrgRespCheckAdvice.java
+++ b/auth/dream-spring-auth-base/src/main/java/com/dream/springframework/auth/base/component/OrgRespCheckAdvice.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dream.springframework.auth.base.component;
+
+import com.dream.springframework.auth.base.service.AuthorizationService;
+import com.dream.springframework.auth.base.service.OrgPermissionService;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Checks organization resource permission and organization based authorities and roles
+ * according to response.
+ *
+ * @author DreamJM
+ */
+@ControllerAdvice
+public class OrgRespCheckAdvice extends OrgCheckService implements ResponseBodyAdvice {
+
+    public OrgRespCheckAdvice(ObjectProvider<OrgPermissionService<?>> permissionProvider, AuthorizationService authService,
+                              HttpServletRequest request) {
+        super(permissionProvider, authService, request, true);
+    }
+
+    @Override
+    public boolean supports(@NonNull MethodParameter returnType, @NonNull Class converterType) {
+        return supports(returnType);
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, @NonNull MethodParameter returnType, @NonNull MediaType selectedContentType,
+                                  @NonNull Class selectedConverterType, @NonNull ServerHttpRequest request,
+                                  @NonNull ServerHttpResponse response) {
+        checkAdvice(body, returnType);
+        return body;
+    }
+}

--- a/auth/dream-spring-auth-token-starter/src/main/java/com/dream/springframework/auth/token/DreamAuthTokenAutoConfiguration.java
+++ b/auth/dream-spring-auth-token-starter/src/main/java/com/dream/springframework/auth/token/DreamAuthTokenAutoConfiguration.java
@@ -16,10 +16,7 @@
 
 package com.dream.springframework.auth.token;
 
-import com.dream.springframework.auth.base.component.AuthenticationInterceptor;
-import com.dream.springframework.auth.base.component.DefaultAuthorizationProvider;
-import com.dream.springframework.auth.base.component.DefaultAuthorizationServiceImpl;
-import com.dream.springframework.auth.base.component.OrgCheckAdvice;
+import com.dream.springframework.auth.base.component.*;
 import com.dream.springframework.auth.base.resolver.LoginUserHandlerMethodArgumentResolver;
 import com.dream.springframework.auth.base.service.AuthorizationProvider;
 import com.dream.springframework.auth.base.service.AuthorizationService;
@@ -87,6 +84,17 @@ public class DreamAuthTokenAutoConfiguration implements WebMvcConfigurer {
     @Bean
     public OrgCheckAdvice orgCheckAdvice(ObjectProvider<OrgPermissionService<?>> orgPermissionProvider, HttpServletRequest request) {
         return new OrgCheckAdvice(orgPermissionProvider, authorizationService(), request);
+    }
+
+    /**
+     * @param orgPermissionProvider ObjectProvider for organization resource access permission checking service
+     * @param request               Http Servlet Request delegate
+     * @return organization response check advice
+     */
+    @Bean
+    public OrgRespCheckAdvice orgRespCheckAdvice(ObjectProvider<OrgPermissionService<?>> orgPermissionProvider,
+                                                 HttpServletRequest request) {
+        return new OrgRespCheckAdvice(orgPermissionProvider, authorizationService(), request);
     }
 
     /**

--- a/dream-spring-demo/src/main/java/com/dream/springframework/demo/controller/OrgController.java
+++ b/dream-spring-demo/src/main/java/com/dream/springframework/demo/controller/OrgController.java
@@ -17,7 +17,6 @@
 package com.dream.springframework.demo.controller;
 
 import com.dream.springframework.auth.base.annotation.OrgAuthorization;
-import com.dream.springframework.auth.base.annotation.OrgPermissionIgnore;
 import com.dream.springframework.auth.base.annotation.RequiredAuthorities;
 import com.dream.springframework.auth.base.annotation.RequiredRoles;
 import com.dream.springframework.demo.model.OrgDemo;
@@ -28,8 +27,8 @@ import com.dream.springframework.demo.service.OrgService;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * @author DreamJM
@@ -74,4 +73,22 @@ public class OrgController {
         return new Organ(id);
     }
 
+    @GetMapping("/api/org-rsp")
+    public OrgDemo testRespOrg(@RequestParam String orgId) {
+        OrgDemo orgDemo = new OrgDemo();
+        orgDemo.setOrgId(orgId);
+        return orgDemo;
+    }
+
+    @RequiredAuthorities("auth3")
+    @GetMapping("/api/orgs-rsp")
+    public @OrgAuthorization List<OrgDemo> testRespOrg(@RequestParam String[] orgIds) {
+        List<OrgDemo> orgs = new ArrayList<>();
+        for (String orgId : orgIds) {
+            OrgDemo orgDemo = new OrgDemo();
+            orgDemo.setOrgId(orgId);
+            orgs.add(orgDemo);
+        }
+        return orgs;
+    }
 }


### PR DESCRIPTION
1. Makes @OrgAuthorization annotation can be annotated on the method
2. When annotated on the method, the response object implementing the CheckedOrg, CheckedOrgs and CheckedOrgList will be used to check authorities and roles